### PR TITLE
refactor: 분산 채팅 환경에서 세션 라우팅 및 Presence 정합성 개선

### DIFF
--- a/src/main/java/bill/chat/ChatApplication.java
+++ b/src/main/java/bill/chat/ChatApplication.java
@@ -4,10 +4,12 @@ import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.mongodb.config.EnableReactiveMongoAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableReactiveMongoAuditing
 @EnableRabbit
+@EnableScheduling
 public class ChatApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/bill/chat/controller/ChatController.java
+++ b/src/main/java/bill/chat/controller/ChatController.java
@@ -1,14 +1,12 @@
 package bill.chat.controller;
 
 import bill.chat.apiPayload.ApiResponse;
-import bill.chat.apiPayload.code.status.ErrorStatus;
-import bill.chat.apiPayload.exception.GeneralException;
 import bill.chat.converter.ChatMessageConverter;
 import bill.chat.dto.ChatMessageResponseDTO.getChatMessage;
 import bill.chat.dto.SSEDTO;
 import bill.chat.service.ChatService;
 import bill.chat.service.DistributedSSEManager;
-import bill.chat.service.SSEManager;
+import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.Sinks;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,17 +46,24 @@ public class ChatController {
             String userId = ctx.get("userId");
 
             return distributedSSEManager.createAndRegisterSink(userId)
-                    .flatMapMany(sink -> sink.asFlux()
-                            .doFinally(signal -> {
-                                log.info("SSE connection cleanup for user: {}", userId);
-                                distributedSSEManager.removeSink(userId);
-                            })
-                    )
+                    .flatMapMany(registration -> {
+                        Flux<SSEDTO> heartbeat = Flux.interval(Duration.ofSeconds(15))
+                                .flatMap(tick -> distributedSSEManager
+                                        .refreshConnection(userId, registration.connectionId())
+                                        .then(Mono.empty()));
+
+                        return registration.sink().asFlux()
+                                .mergeWith(heartbeat)
+                                .doOnSubscribe(subscription -> distributedSSEManager
+                                        .refreshConnection(userId, registration.connectionId())
+                                        .subscribe())
+                                .doFinally(signal -> {
+                                    log.info("SSE connection cleanup for user: {}, connId={}", userId,
+                                            registration.connectionId());
+                                    distributedSSEManager.removeSink(userId, registration.connectionId());
+                                });
+                    })
                     .onErrorResume(e -> {
-                        if (e instanceof IllegalStateException) {
-                            log.warn("중복 구독 시도: {}", userId);
-                            return Flux.error(new GeneralException(ErrorStatus.DUPLICATION_SUBSCRIBE));
-                        }
                         log.error("SSE 구독 중 오류 발생", e);
                         return Flux.error(e);
                     });

--- a/src/main/java/bill/chat/rabbitMQ/ChatProcessor.java
+++ b/src/main/java/bill/chat/rabbitMQ/ChatProcessor.java
@@ -78,7 +78,7 @@ public class ChatProcessor {
                                                     savedMessage.getCreatedAt(),
                                                     savedMessage.isRead());
 
-                                            return mqProducer.broadcastProcessedMessage(successDTO)
+                                            return dispatchWebSocketMessage(chatRoom.getChannelId(), successDTO)
                                                     .then(sendNotificationsToOtherUsers(chatRoom, chatDTO,
                                                             savedMessage));
                                         });
@@ -93,7 +93,7 @@ public class ChatProcessor {
 
     private Mono<Void> sendNotificationsToOtherUsers(ChatRoom chatRoom, ChatDTO chatDTO, ChatMessage savedMessage) {
         String senderId = chatDTO.getSenderId();
-        String channelId = chatRoom.getChannelId(); // 👈 channelId를 가져옵니다.
+        String channelId = chatRoom.getChannelId();
 
         return Flux.fromIterable(chatRoom.getParticipants())
                 .filter(participant -> !participant.getUserId().equals(senderId))
@@ -108,21 +108,22 @@ public class ChatProcessor {
                                     return Mono.empty();
                                 }
 
-                                return distributedSSEManager.hasAnySSEConnection(targetUserId)
-                                        .flatMap(hasSSE -> {
-                                            if (hasSSE) {
-                                                log.info("Target user {} is online via SSE. Sending SSE message.",
-                                                        targetUserId);
-                                                return mqProducer.sendSSEMessage(SSEDTO.builder()
-                                                        .targetUserId(targetUserId)
-                                                        .channelId(chatRoom.getChannelId())
-                                                        .senderId(chatDTO.getSenderId())
-                                                        .content(savedMessage.getContent())
-                                                        .unreadCount(chatRoom.getUnreadCount())
-                                                        .notification(participant.isNotification())
-                                                        .updatedAt(chatRoom.getUpdatedAt())
-                                                        .build());
-                                            } else if (participant.isNotification()) {
+                                return distributedSSEManager.findConnectedServerId(targetUserId)
+                                        .flatMap(serverId -> {
+                                            log.info("Target user {} is online via SSE. Sending SSE message to server {}.",
+                                                    targetUserId, serverId);
+                                            return mqProducer.sendSSEMessageToServer(serverId, SSEDTO.builder()
+                                                    .targetUserId(targetUserId)
+                                                    .channelId(chatRoom.getChannelId())
+                                                    .senderId(chatDTO.getSenderId())
+                                                    .content(savedMessage.getContent())
+                                                    .unreadCount(chatRoom.getUnreadCount())
+                                                    .notification(participant.isNotification())
+                                                    .updatedAt(chatRoom.getUpdatedAt())
+                                                    .build());
+                                        })
+                                        .switchIfEmpty(Mono.defer(() -> {
+                                            if (participant.isNotification()) {
                                                 log.info("Target user {} is offline. Sending Push message.",
                                                         targetUserId);
                                                 return mqProducer.sendPushMessage(PushDTO.builder()
@@ -133,8 +134,15 @@ public class ChatProcessor {
                                                         .build());
                                             }
                                             return Mono.empty();
-                                        });
+                                        }));
                             });
                 }).then();
+    }
+
+    private Mono<Void> dispatchWebSocketMessage(String channelId, WebSocketSuccessDTO successDTO) {
+        return distributedSessionManager.getActiveServerIds(channelId)
+                .flatMapMany(Flux::fromIterable)
+                .flatMap(serverId -> mqProducer.sendWebSocketMessageToServer(serverId, successDTO))
+                .then();
     }
 }

--- a/src/main/java/bill/chat/rabbitMQ/Producer.java
+++ b/src/main/java/bill/chat/rabbitMQ/Producer.java
@@ -19,34 +19,34 @@ public class Producer {
 
     public Mono<Void> sendChatMessage(ChatDTO chatDTO) {
         return Mono.fromRunnable(() -> {
-                    try {
-                        rabbitTemplate.convertAndSend("chat.processing.exchange", "chat.process", chatDTO);
-                        log.info("채팅 메시지 MQ 전송 성공: channelId={}", chatDTO.getChannelId());
-                    } catch (Exception e) {
-                        log.error("채팅 메시지 MQ 전송 실패: channelId={}, error={}", chatDTO.getChannelId(), e.getMessage());
-                        throw new RuntimeException("MQ 전송 실패", e);
-                    }
-                })
+            try {
+                rabbitTemplate.convertAndSend("chat.processing.exchange", "chat.process", chatDTO);
+                log.info("채팅 메시지 MQ 전송 성공: channelId={}", chatDTO.getChannelId());
+            } catch (Exception e) {
+                log.error("채팅 메시지 MQ 전송 실패: channelId={}, error={}", chatDTO.getChannelId(), e.getMessage());
+                throw new RuntimeException("MQ 전송 실패", e);
+            }
+        })
                 .subscribeOn(Schedulers.boundedElastic())
                 .then();
     }
 
-    public Mono<Void> broadcastProcessedMessage(WebSocketSuccessDTO successDTO) {
+    public Mono<Void> sendWebSocketMessageToServer(String serverId, WebSocketSuccessDTO successDTO) {
         return Mono.fromRunnable(() -> {
             try {
-                rabbitTemplate.convertAndSend("chat.exchange", "", successDTO);
-                log.info("메시지 브로드캐스트 성공: channelId={}", successDTO.getChannelId());
+                rabbitTemplate.convertAndSend("chat.ws.exchange", "ws.server." + serverId, successDTO);
+                log.info("WS 메시지 서버 라우팅 성공: channelId={}, serverId={}", successDTO.getChannelId(), serverId);
             } catch (Exception e) {
-                throw new RuntimeException("메세지 브로드캐스트 실패", e);
+                throw new RuntimeException("WS 메시지 라우팅 실패", e);
             }
         }).subscribeOn(Schedulers.boundedElastic()).then();
     }
 
-    public Mono<Void> sendSSEMessage(SSEDTO ssedto) {
+    public Mono<Void> sendSSEMessageToServer(String serverId, SSEDTO ssedto) {
         return Mono.fromRunnable(() -> {
             try {
-                rabbitTemplate.convertAndSend("sse.exchange", ssedto.getTargetUserId(), ssedto);
-                log.info("SSE 메시지 MQ 전송 성공: targetUserId={}", ssedto.getTargetUserId());
+                rabbitTemplate.convertAndSend("chat.sse.exchange", "sse.server." + serverId, ssedto);
+                log.info("SSE 메시지 서버 라우팅 성공: targetUserId={}, serverId={}", ssedto.getTargetUserId(), serverId);
             } catch (Exception e) {
                 log.error("SSE 메시지 MQ 전송 실패: targetUserId={}, error={}", ssedto.getTargetUserId(), e.getMessage());
                 throw new RuntimeException("MQ 전송 실패", e);
@@ -57,7 +57,7 @@ public class Producer {
     public Mono<Void> sendPushMessage(PushDTO pushdto) {
         return Mono.fromRunnable(() -> {
             try {
-                rabbitTemplate.convertAndSend("push.exchange", pushdto.getUserId(), pushdto);
+                rabbitTemplate.convertAndSend("push.exchange", "push", pushdto);
                 log.info("Push 메시지 MQ 전송 성공: targetUserId={}", pushdto.getUserId());
             } catch (Exception e) {
                 log.error("Push 메시지 MQ 전송 실패: targetUserId={}, error={}", pushdto.getUserId(), e.getMessage());

--- a/src/main/java/bill/chat/rabbitMQ/RabbitMQConfig.java
+++ b/src/main/java/bill/chat/rabbitMQ/RabbitMQConfig.java
@@ -1,5 +1,7 @@
 package bill.chat.rabbitMQ;
 
+import bill.chat.service.ServerInstanceIdProvider;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
@@ -7,7 +9,7 @@ import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.FanoutExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.AnonymousQueue;
-import org.springframework.amqp.core.TopicExchange;
+
 import org.springframework.amqp.rabbit.config.RetryInterceptorBuilder;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
@@ -29,6 +31,7 @@ import org.springframework.retry.support.RetryTemplate;
 
 @Configuration
 @Slf4j
+@RequiredArgsConstructor
 public class RabbitMQConfig {
     @Value("${spring.rabbitmq.host}")
     private String host;
@@ -39,22 +42,24 @@ public class RabbitMQConfig {
     @Value("${spring.rabbitmq.port}")
     private int port;
 
-    // 채팅 메시지 브로드캐스트용
+    private final ServerInstanceIdProvider serverInstanceIdProvider;
+
+    // 채팅 메시지 전송용 (서버 타겟 라우팅)
     @Bean
-    public FanoutExchange chatExchange() {
-        return new FanoutExchange("chat.exchange");
+    public DirectExchange chatExchange() {
+        return new DirectExchange("chat.ws.exchange");
     }
 
-    // SSE 메시지 전송용
+    // SSE 메시지 전송용 (서버 타겟 라우팅)
     @Bean
-    public TopicExchange sseExchange() {
-        return new TopicExchange("sse.exchange");
+    public DirectExchange sseExchange() {
+        return new DirectExchange("chat.sse.exchange");
     }
 
     // Push 알림 메시지 전송용
     @Bean
-    public TopicExchange pushExchange() {
-        return new TopicExchange("push.exchange");
+    public DirectExchange pushExchange() {
+        return new DirectExchange("push.exchange");
     }
 
     // 메세지 저장용
@@ -65,12 +70,14 @@ public class RabbitMQConfig {
 
     @Bean
     public Queue chatQueue() {
-        return new AnonymousQueue();
+        String serverId = serverInstanceIdProvider.getServerInstanceId();
+        return new Queue("chat.ws.server." + serverId + ".q", true);
     }
 
     @Bean
     public Queue sseQueue() {
-        return new AnonymousQueue();
+        String serverId = serverInstanceIdProvider.getServerInstanceId();
+        return new Queue("chat.sse.server." + serverId + ".q", true);
     }
 
     @Bean
@@ -89,18 +96,20 @@ public class RabbitMQConfig {
     }
 
     @Bean
-    public Binding chatQueueBinding(@Qualifier("chatQueue") Queue queue, FanoutExchange chatExchange) {
-        return BindingBuilder.bind(queue).to(chatExchange);
+    public Binding chatQueueBinding(@Qualifier("chatQueue") Queue queue, DirectExchange chatExchange) {
+        String serverId = serverInstanceIdProvider.getServerInstanceId();
+        return BindingBuilder.bind(queue).to(chatExchange).with("ws.server." + serverId);
     }
 
     @Bean
-    public Binding sseQueueBinding(@Qualifier("sseQueue") Queue queue, TopicExchange sseExchange) {
-        return BindingBuilder.bind(queue).to(sseExchange).with("#");
+    public Binding sseQueueBinding(@Qualifier("sseQueue") Queue queue, DirectExchange sseExchange) {
+        String serverId = serverInstanceIdProvider.getServerInstanceId();
+        return BindingBuilder.bind(queue).to(sseExchange).with("sse.server." + serverId);
     }
 
     @Bean
-    public Binding pushQueueBinding(@Qualifier("pushQueue") Queue queue, TopicExchange pushExchange) {
-        return BindingBuilder.bind(queue).to(pushExchange).with("#");
+    public Binding pushQueueBinding(@Qualifier("pushQueue") Queue queue, DirectExchange pushExchange) {
+        return BindingBuilder.bind(queue).to(pushExchange).with("push");
     }
 
     // 에러 메시지 브로드캐스트용

--- a/src/main/java/bill/chat/rabbitMQ/Receiver.java
+++ b/src/main/java/bill/chat/rabbitMQ/Receiver.java
@@ -30,21 +30,22 @@ public class Receiver {
 
     @RabbitListener(queues = "#{sseQueue.name}")
     public void consumeSSEMessage(SSEDTO ssedto) {
-        log.info("SSE 큐에서 메시지 수신 성공 Target: {}", ssedto.getTargetUserId());
+        String targetUserId = ssedto.getTargetUserId();
+        log.info("SSE 큐에서 메시지 수신 성공 Target: {}", targetUserId);
         try {
-            boolean isPresent = distributedSSEManager.hasLocalSSEConnection(ssedto.getTargetUserId());
-            log.info("로컬 SSE 연결 확인: Target={}, isPresent={}", ssedto.getTargetUserId(), isPresent);
+            boolean isPresent = distributedSSEManager.hasLocalSSEConnection(targetUserId);
+            log.info("로컬 SSE 연결 확인: Target={}, isPresent={}", targetUserId, isPresent);
 
             if (isPresent) {
                 log.info("로컬 SSE 연결 존재. 메시지 전송 시도...");
                 boolean success = distributedSSEManager.sendToLocalSSE(ssedto);
                 if (!success) {
-                    log.warn("로컬 SSE 전송 실패: targetUserId={}", ssedto.getTargetUserId());
+                    log.warn("로컬 SSE 전송 실패: targetUserId={}", targetUserId);
                 } else {
                     log.info("로컬 SSE 메시지 전송 성공");
                 }
             } else {
-                log.info("이 서버에 해당 사용자의 로컬 SSE 연결이 없음. Target User: {}", ssedto.getTargetUserId());
+                log.info("이 서버에 해당 사용자의 로컬 SSE 연결이 없음. Target User: {}", targetUserId);
             }
         } catch (Exception e) {
             log.error("SSE 메시지 수신 처리 중 예외 발생", e);

--- a/src/main/java/bill/chat/service/DistributedSSEManager.java
+++ b/src/main/java/bill/chat/service/DistributedSSEManager.java
@@ -2,6 +2,8 @@ package bill.chat.service;
 
 import bill.chat.dto.SSEDTO;
 import java.time.LocalDateTime;
+import java.time.Duration;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
@@ -9,7 +11,6 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,33 +21,38 @@ import reactor.core.publisher.Sinks.Many;
 @Slf4j
 public class DistributedSSEManager {
 
-    private final Map<String, Sinks.Many<SSEDTO>> localSinks = new ConcurrentHashMap<>();
+    private final Map<String, LocalSSEConnection> localSinks = new ConcurrentHashMap<>();
     private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final ServerInstanceIdProvider serverInstanceIdProvider;
     private static final String SSE_PREFIX = "chat:sse:";
-    private static final Duration SSE_TTL = Duration.ofMinutes(90);
+    private static final Duration SSE_TTL = Duration.ofSeconds(60);
 
-    public Mono<Many<SSEDTO>> createAndRegisterSink(String userId) {
-        if (localSinks.containsKey(userId) && localSinks.get(userId).currentSubscriberCount() > 0) {
-            return Mono.error(new IllegalStateException("이미 구독 중인 사용자입니다."));
+    public Mono<SSEConnectionRegistration> createAndRegisterSink(String userId) {
+        String connectionId = UUID.randomUUID().toString();
+        String serverInstance = serverInstanceIdProvider.getServerInstanceId();
+        String redisValue = serverInstance + ":" + connectionId;
+
+        // 동일 유저 재구독 시 최신 연결로 takeover
+        LocalSSEConnection previous = localSinks.get(userId);
+        if (previous != null) {
+            previous.sink().tryEmitComplete();
         }
 
-        String serverInstance = getServerInstanceId();
+        Sinks.Many<SSEDTO> sink = Sinks.many()
+                .unicast()
+                .onBackpressureBuffer(new ArrayBlockingQueue<>(100));
+        localSinks.put(userId, new LocalSSEConnection(connectionId, sink));
+
         String sseKey = SSE_PREFIX + userId;
-        return redisTemplate.opsForValue().set(sseKey, serverInstance, SSE_TTL)
+        return redisTemplate.opsForValue().set(sseKey, redisValue, SSE_TTL)
                 .doOnSuccess(success -> {
                     if (Boolean.TRUE.equals(success)) {
-                        log.info("Redis에 SSE 연결 정보 저장 성공: {}", userId);
+                        log.info("Redis에 SSE 연결 정보 저장 성공: userId={}, connId={}", userId, connectionId);
                     } else {
                         log.warn("Redis에 SSE 연결 정보 저장 실패: {}", userId);
                     }
                 })
                 .then(Mono.fromCallable(() -> {
-                    Sinks.Many<SSEDTO> sink = Sinks.many()
-                            .unicast()
-                            .onBackpressureBuffer(new ArrayBlockingQueue<>(100));
-
-                    localSinks.put(userId, sink);
-
                     SSEDTO initialMessage = SSEDTO.builder()
                             .channelId("system")
                             .senderId("server")
@@ -58,46 +64,78 @@ public class DistributedSSEManager {
 
                     sink.tryEmitNext(initialMessage);
 
-                    return sink;
+                    return new SSEConnectionRegistration(connectionId, sink);
                 }));
     }
 
     public boolean hasLocalSSEConnection(String userId) {
-        Sinks.Many<SSEDTO> foundSink = localSinks.get(userId);
-        return foundSink != null && foundSink.currentSubscriberCount() > 0;
+        LocalSSEConnection foundSink = localSinks.get(userId);
+        return foundSink != null && foundSink.sink().currentSubscriberCount() > 0;
     }
 
-    public reactor.core.publisher.Mono<Boolean> hasAnySSEConnection(String userId) {
+    public Mono<String> findConnectedServerId(String userId) {
         String sseKey = SSE_PREFIX + userId;
-        return redisTemplate.hasKey(sseKey);
+        return redisTemplate.opsForValue().get(sseKey)
+                .map(this::extractServerId);
     }
 
-    public void removeSink(String userId) {
-        Sinks.Many<SSEDTO> sink = localSinks.get(userId);
-        if (sink != null) {
-            sink.tryEmitComplete();
-            localSinks.remove(userId);
+    public Mono<Void> refreshConnection(String userId, String connectionId) {
+        LocalSSEConnection local = localSinks.get(userId);
+        if (local == null || !local.connectionId().equals(connectionId)) {
+            return Mono.empty();
+        }
+        String value = serverInstanceIdProvider.getServerInstanceId() + ":" + connectionId;
+        String sseKey = SSE_PREFIX + userId;
+        return redisTemplate.opsForValue().set(sseKey, value, SSE_TTL).then();
+    }
+
+    public void removeSink(String userId, String connectionId) {
+        LocalSSEConnection sink = localSinks.get(userId);
+        if (sink == null || !sink.connectionId().equals(connectionId)) {
+            return;
         }
 
-        // Redis에서도 제거
-        unregisterSSEConnection(userId);
+        sink.sink().tryEmitComplete();
+        localSinks.remove(userId);
+        unregisterSSEConnectionIfMatched(userId, connectionId);
     }
 
     public boolean sendToLocalSSE(SSEDTO message) {
-        Sinks.Many<SSEDTO> sink = localSinks.get(message.getTargetUserId());
-        if (sink != null && sink.currentSubscriberCount() > 0) {
-            sink.tryEmitNext(message);
+        LocalSSEConnection sink = localSinks.get(message.getTargetUserId());
+        if (sink != null && sink.sink().currentSubscriberCount() > 0) {
+            sink.sink().tryEmitNext(message);
             return true;
         }
         return false;
     }
 
-    private void unregisterSSEConnection(String userId) {
+    private void unregisterSSEConnectionIfMatched(String userId, String connectionId) {
         String sseKey = SSE_PREFIX + userId;
-        redisTemplate.delete(sseKey).subscribe();
+        String expectedValue = serverInstanceIdProvider.getServerInstanceId() + ":" + connectionId;
+        redisTemplate.opsForValue().get(sseKey)
+                .flatMap(currentValue -> {
+                    if (expectedValue.equals(currentValue)) {
+                        return redisTemplate.delete(sseKey);
+                    }
+                    return Mono.just(false);
+                })
+                .subscribe();
     }
 
-    private String getServerInstanceId() {
-        return System.getProperty("server.instance.id", "server-" + System.currentTimeMillis());
+    private String extractServerId(String value) {
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+        int delimiter = value.indexOf(':');
+        if (delimiter <= 0) {
+            return value;
+        }
+        return value.substring(0, delimiter);
+    }
+
+    private record LocalSSEConnection(String connectionId, Sinks.Many<SSEDTO> sink) {
+    }
+
+    public record SSEConnectionRegistration(String connectionId, Sinks.Many<SSEDTO> sink) {
     }
 }

--- a/src/main/java/bill/chat/service/DistributedSessionManager.java
+++ b/src/main/java/bill/chat/service/DistributedSessionManager.java
@@ -4,8 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -13,28 +20,33 @@ import java.time.Duration;
 public class DistributedSessionManager {
 
     private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final ServerInstanceIdProvider serverInstanceIdProvider;
     private static final String CHANNEL_USERS_PREFIX = "chat:channel:users:"; // Hash Key
+    private static final String CHANNEL_SERVERS_PREFIX = "chat:channel:servers:"; // Hash Key
     private static final String SESSION_PREFIX = "chat:session:"; // String Key (Reverse Index)
 
-    private static final Duration SESSION_TTL = Duration.ofMinutes(5);
+    private static final Duration SESSION_TTL = Duration.ofSeconds(75);
 
     /**
      * 입장 처리
      */
     public Mono<Void> addSessionToChannel(String channelId, String sessionId, String userId) {
+        String serverId = serverInstanceIdProvider.getServerInstanceId();
         String sessionKey = SESSION_PREFIX + sessionId;
         String channelUsersKey = CHANNEL_USERS_PREFIX + channelId;
+        String channelServersKey = CHANNEL_SERVERS_PREFIX + channelId;
 
         // 1. 세션 -> 유저 매핑 (역인덱스)
-        Mono<Boolean> saveSession = redisTemplate.opsForValue().set(sessionKey, userId, SESSION_TTL);
+        Mono<Boolean> saveSession = redisTemplate.opsForValue()
+                .set(sessionKey, channelId + "|" + userId + "|" + serverId, SESSION_TTL);
 
         // 2. 채널별 유저 접속 수 증가 (Reference Counting)
         Mono<Long> incrementUserCount = redisTemplate.opsForHash().increment(channelUsersKey, userId, 1);
 
-        // 3. TTL 갱신 (채널 키 자체의 TTL)
-        Mono<Boolean> expireChannel = redisTemplate.expire(channelUsersKey, SESSION_TTL);
+        // 3. 채널별 서버 접속 수 증가
+        Mono<Long> incrementServerCount = redisTemplate.opsForHash().increment(channelServersKey, serverId, 1);
 
-        return Mono.when(saveSession, incrementUserCount, expireChannel)
+        return Mono.when(saveSession, incrementUserCount, incrementServerCount)
                 .doOnSuccess(unused -> log.info("세션 등록 완료: channelId={}, userId={}, sessionId={}", channelId, userId,
                         sessionId))
                 .then();
@@ -52,8 +64,10 @@ public class DistributedSessionManager {
      * 세션 종료 및 채널 퇴장 처리
      */
     public Mono<Void> removeSessionFromChannel(String channelId, String sessionId, String userId) {
+        String serverId = serverInstanceIdProvider.getServerInstanceId();
         String sessionKey = SESSION_PREFIX + sessionId;
         String channelUsersKey = CHANNEL_USERS_PREFIX + channelId;
+        String channelServersKey = CHANNEL_SERVERS_PREFIX + channelId;
 
         return redisTemplate.delete(sessionKey)
 
@@ -62,6 +76,13 @@ public class DistributedSessionManager {
                             if (count <= 0) {
                                 // 카운트가 0이 되면 해시에서 필드 제거 (진짜 퇴장)
                                 return redisTemplate.opsForHash().remove(channelUsersKey, (Object) userId);
+                            }
+                            return Mono.just(count);
+                        }))
+                .then(redisTemplate.opsForHash().increment(channelServersKey, serverId, -1)
+                        .flatMap(count -> {
+                            if (count <= 0) {
+                                return redisTemplate.opsForHash().remove(channelServersKey, (Object) serverId);
                             }
                             return Mono.just(count);
                         }))
@@ -80,6 +101,123 @@ public class DistributedSessionManager {
 
     public Mono<Void> refreshSession(String sessionId) {
         String sessionKey = SESSION_PREFIX + sessionId;
-        return redisTemplate.expire(sessionKey, SESSION_TTL).then();
+        return redisTemplate.opsForValue().get(sessionKey)
+                .flatMap(sessionValue -> {
+                    Mono<Boolean> refreshSession = redisTemplate.expire(sessionKey, SESSION_TTL);
+                    return refreshSession.then();
+                })
+                .switchIfEmpty(redisTemplate.expire(sessionKey, SESSION_TTL).then());
+    }
+
+    public Mono<Set<String>> getActiveServerIds(String channelId) {
+        String channelServersKey = CHANNEL_SERVERS_PREFIX + channelId;
+        return redisTemplate.opsForHash().keys(channelServersKey)
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+    }
+
+    public Mono<Void> reconcilePresenceFromSessionIndex() {
+        Mono<List<String>> sessionValuesMono = redisTemplate.keys(SESSION_PREFIX + "*")
+                .flatMap(sessionKey -> redisTemplate.opsForValue().get(sessionKey))
+                .collectList();
+
+        return sessionValuesMono.flatMap(sessionValues -> {
+            Map<String, Map<Object, Object>> channelUserCounts = new HashMap<>();
+            Map<String, Map<Object, Object>> channelServerCounts = new HashMap<>();
+
+            for (String sessionValue : sessionValues) {
+                SessionMeta meta = parseSessionMeta(sessionValue);
+                if (meta == null) {
+                    continue;
+                }
+
+                String channelId = meta.channelId();
+                String userId = meta.userId();
+                String serverId = meta.serverId();
+
+                channelUserCounts.computeIfAbsent(channelId, k -> new HashMap<>());
+                channelServerCounts.computeIfAbsent(channelId, k -> new HashMap<>());
+
+                Map<Object, Object> userMap = channelUserCounts.get(channelId);
+                Map<Object, Object> serverMap = channelServerCounts.get(channelId);
+
+                long userCount = ((Number) userMap.getOrDefault(userId, 0L)).longValue() + 1L;
+                long serverCount = ((Number) serverMap.getOrDefault(serverId, 0L)).longValue() + 1L;
+
+                userMap.put(userId, userCount);
+                serverMap.put(serverId, serverCount);
+            }
+
+            Mono<List<String>> existingUserKeysMono = redisTemplate.keys(CHANNEL_USERS_PREFIX + "*").collectList();
+            Mono<List<String>> existingServerKeysMono = redisTemplate.keys(CHANNEL_SERVERS_PREFIX + "*").collectList();
+
+            return Mono.zip(existingUserKeysMono, existingServerKeysMono)
+                    .flatMap(existingKeys -> {
+                        List<Mono<Void>> tasks = new ArrayList<>();
+
+                        List<String> existingUserKeys = existingKeys.getT1();
+                        List<String> existingServerKeys = existingKeys.getT2();
+
+                        Set<String> targetUserKeys = channelUserCounts.keySet().stream()
+                                .map(channelId -> CHANNEL_USERS_PREFIX + channelId)
+                                .collect(Collectors.toSet());
+                        Set<String> targetServerKeys = channelServerCounts.keySet().stream()
+                                .map(channelId -> CHANNEL_SERVERS_PREFIX + channelId)
+                                .collect(Collectors.toSet());
+
+                        for (String key : existingUserKeys) {
+                            if (!targetUserKeys.contains(key)) {
+                                tasks.add(redisTemplate.delete(key).then());
+                            }
+                        }
+                        for (String key : existingServerKeys) {
+                            if (!targetServerKeys.contains(key)) {
+                                tasks.add(redisTemplate.delete(key).then());
+                            }
+                        }
+
+                        for (Map.Entry<String, Map<Object, Object>> entry : channelUserCounts.entrySet()) {
+                            String channelId = entry.getKey();
+                            String key = CHANNEL_USERS_PREFIX + channelId;
+                            Map<Object, Object> hash = entry.getValue();
+                            tasks.add(rewriteHash(key, hash));
+                        }
+
+                        for (Map.Entry<String, Map<Object, Object>> entry : channelServerCounts.entrySet()) {
+                            String channelId = entry.getKey();
+                            String key = CHANNEL_SERVERS_PREFIX + channelId;
+                            Map<Object, Object> hash = entry.getValue();
+                            tasks.add(rewriteHash(key, hash));
+                        }
+
+                        if (tasks.isEmpty()) {
+                            return Mono.empty();
+                        }
+                        return Mono.when(tasks).then();
+                    });
+        });
+    }
+
+    private Mono<Void> rewriteHash(String key, Map<Object, Object> values) {
+        if (values.isEmpty()) {
+            return redisTemplate.delete(key).then();
+        }
+        return redisTemplate.delete(key)
+                .then(redisTemplate.opsForHash().putAll(key, values))
+                .then();
+    }
+
+    private SessionMeta parseSessionMeta(String sessionValue) {
+        if (sessionValue == null || sessionValue.isBlank()) {
+            return null;
+        }
+        String[] parts = sessionValue.split("\\|");
+        if (parts.length != 3) {
+            return null;
+        }
+        return new SessionMeta(parts[0], parts[1], parts[2]);
+    }
+
+    private record SessionMeta(String channelId, String userId, String serverId) {
     }
 }

--- a/src/main/java/bill/chat/service/ServerInstanceIdProvider.java
+++ b/src/main/java/bill/chat/service/ServerInstanceIdProvider.java
@@ -1,0 +1,45 @@
+package bill.chat.service;
+
+import java.net.InetAddress;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Slf4j
+public class ServerInstanceIdProvider {
+
+    private final String serverInstanceId;
+
+    public ServerInstanceIdProvider(
+            @Value("${server.instance.id:}") String configuredServerInstanceId,
+            @Value("${spring.application.name:chat-server}") String appName,
+            @Value("${server.port:0}") String port) {
+
+        if (configuredServerInstanceId != null && !configuredServerInstanceId.isBlank()) {
+            this.serverInstanceId = configuredServerInstanceId;
+            log.info("Using configured server instance id: {}", this.serverInstanceId);
+            return;
+        }
+
+        String hostname = resolveHostname();
+        if (hostname == null || hostname.isBlank()) {
+            hostname = "unknown-host";
+        }
+
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        this.serverInstanceId = appName + "-" + hostname + "-" + port + "-" + suffix;
+        log.info("Generated server instance id: {}", this.serverInstanceId);
+    }
+
+    private String resolveHostname() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (Exception e) {
+            return System.getenv("HOSTNAME");
+        }
+    }
+}

--- a/src/main/java/bill/chat/service/SessionPresenceReconciler.java
+++ b/src/main/java/bill/chat/service/SessionPresenceReconciler.java
@@ -1,0 +1,27 @@
+package bill.chat.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SessionPresenceReconciler {
+
+    private final DistributedSessionManager distributedSessionManager;
+
+    @Scheduled(
+            initialDelayString = "${chat.session-reconcile.initial-delay-ms:60000}",
+            fixedDelayString = "${chat.session-reconcile.fixed-delay-ms:30000}")
+    public void reconcilePresence() {
+        try {
+            distributedSessionManager.reconcilePresenceFromSessionIndex()
+                    .block(Duration.ofSeconds(20));
+        } catch (Exception e) {
+            log.warn("세션 Presence 재조정 실패", e);
+        }
+    }
+}

--- a/src/main/java/bill/chat/websocket/handler/MyWebSocketHandler.java
+++ b/src/main/java/bill/chat/websocket/handler/MyWebSocketHandler.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -36,7 +37,8 @@ public class MyWebSocketHandler implements WebSocketHandler {
     private final Producer producer;
     private final ChatService chatService;
 
-    private static final Duration PING_INTERVAL = Duration.ofSeconds(30);
+    private static final Duration PING_INTERVAL = Duration.ofSeconds(20);
+    private static final Duration PONG_TIMEOUT = Duration.ofSeconds(45);
 
     @Override
     public List<String> getSubProtocols() {
@@ -48,14 +50,21 @@ public class MyWebSocketHandler implements WebSocketHandler {
         String channelId = getChannelId(session);
         String userId = (String) session.getAttributes().get("userId");
         String sessionId = session.getId();
+        AtomicLong lastSeenAt = new AtomicLong(System.currentTimeMillis());
 
         log.info("WebSocket 연결 시작: userId={}, channelId={}, sessionId={}", userId, channelId, sessionId);
 
         sessions.computeIfAbsent(channelId, id -> new CopyOnWriteArrayList<>()).add(session);
 
         Disposable heartbeatDisposable = Flux.interval(PING_INTERVAL)
-                .flatMap(tick -> session.send(Mono.just(
-                        new WebSocketMessage(WebSocketMessage.Type.PING, session.bufferFactory().wrap("".getBytes())))))
+                .flatMap(tick -> session.send(Mono.just(session.textMessage("ping"))))
+                .doOnNext(unused -> {
+                    long idleMillis = System.currentTimeMillis() - lastSeenAt.get();
+                    if (idleMillis > PONG_TIMEOUT.toMillis() && session.isOpen()) {
+                        log.warn("PONG/메시지 미수신으로 세션 종료: sessionId={}, idleMillis={}", sessionId, idleMillis);
+                        session.close(new CloseStatus(4008, "HEARTBEAT_TIMEOUT")).subscribe();
+                    }
+                })
                 .doOnError(e -> log.error("하트비트 PING 전송 실패", e))
                 .subscribeOn(Schedulers.single())
                 .subscribe();
@@ -63,10 +72,7 @@ public class MyWebSocketHandler implements WebSocketHandler {
         return distributedSessionManager.addSessionToChannel(channelId, sessionId, userId)
                 .then(chatService.markMessagesAsRead(channelId, userId))
                 .then(session.receive()
-                        .doOnNext(message -> {
-                            distributedSessionManager.refreshSession(sessionId).subscribe(); // TTL 갱신
-                        })
-                        .flatMap(message -> handleAndSendToMQ(session, channelId, message.getPayloadAsText()))
+                        .flatMap(message -> handleIncomingMessage(session, channelId, sessionId, lastSeenAt, message))
                         .then())
                 .doFinally(signalType -> {
                     log.info("WebSocket 연결 종료: {}, 종료 원인: {}", sessionId, signalType);
@@ -77,23 +83,42 @@ public class MyWebSocketHandler implements WebSocketHandler {
                 .onErrorResume(e -> session.close(new CloseStatus(4999, "UNKNOWN_ERROR")));
     }
 
-    private Mono<Void> handleAndSendToMQ(WebSocketSession session, String channelId, String payload) {
+    private Mono<Void> handleIncomingMessage(WebSocketSession session, String channelId, String sessionId,
+            AtomicLong lastSeenAt, WebSocketMessage message) {
+        if (message.getType() != WebSocketMessage.Type.TEXT) {
+            lastSeenAt.set(System.currentTimeMillis());
+            return distributedSessionManager.refreshSession(sessionId).then();
+        }
+
+        String payload = message.getPayloadAsText();
         if (payload == null || payload.isBlank()) {
             return Mono.empty();
         }
 
-        if ("ping".equals(payload)) {
-            return distributedSessionManager.refreshSession(session.getId()).then();
-        } else {
-            try {
-                ChatDTO chatDTO = parseChatMessage(payload);
-                chatDTO.setChannelId(channelId);
-                return producer.sendChatMessage(chatDTO);
-            } catch (JsonProcessingException e) {
-                log.error("메시지 파싱 오류: {}", payload, e);
-                return session.close(new CloseStatus(4005, "MESSAGE_TYPE_ERROR"));
-            }
+        if ("pong".equals(payload)) {
+            lastSeenAt.set(System.currentTimeMillis());
+            return distributedSessionManager.refreshSession(sessionId).then();
         }
+
+        if ("ping".equals(payload)) {
+            lastSeenAt.set(System.currentTimeMillis());
+            return distributedSessionManager.refreshSession(sessionId)
+                    .then(session.send(Mono.just(session.textMessage("pong"))))
+                    .then();
+        }
+
+        lastSeenAt.set(System.currentTimeMillis());
+        return distributedSessionManager.refreshSession(sessionId)
+                .then(Mono.defer(() -> {
+                    try {
+                        ChatDTO chatDTO = parseChatMessage(payload);
+                        chatDTO.setChannelId(channelId);
+                        return producer.sendChatMessage(chatDTO);
+                    } catch (JsonProcessingException e) {
+                        log.error("메시지 파싱 오류: {}", payload, e);
+                        return session.close(new CloseStatus(4005, "MESSAGE_TYPE_ERROR"));
+                    }
+                }));
     }
 
     public Mono<Void> broadcastToLocalSessions(String channelId, WebSocketSuccessDTO successDTO) {


### PR DESCRIPTION
- ServerInstanceIdProvider 도입 및 인스턴스별 식별자 기반 라우팅 키 사용
- RabbitMQ를 Direct Exchange 중심으로 개편해 WS/SSE를 서버 타겟 라우팅으로 전환
- SessionPresenceReconciler 스케줄러 추가로 역인덱스 기준 파생 카운트 재계산/정리
- channel users/servers 키 TTL 제거, session TTL(75s) 기반 + reconcile 스케쥴러 방식으로 정합성 향상
- WebSocket 앱 레벨 heartbeat(ping/pong) 및 timeout(45s) 종료 로직 추가